### PR TITLE
Add role enum and field to User entity

### DIFF
--- a/src/main/java/mayankSuperApp/auth_service/entity/Role.java
+++ b/src/main/java/mayankSuperApp/auth_service/entity/Role.java
@@ -1,0 +1,6 @@
+package mayankSuperApp.auth_service.entity;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/mayankSuperApp/auth_service/entity/User.java
+++ b/src/main/java/mayankSuperApp/auth_service/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -44,6 +45,10 @@ public class User {
     @Column(name = "provider_id", nullable = false, length = 100)
     private String providerId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private Role role = Role.USER;
+
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = true;
 
@@ -60,11 +65,17 @@ public class User {
 
     // Constructor for OAuth2 user creation
     public User(String name, String email, String pictureUrl, String provider, String providerId) {
+        this(name, email, pictureUrl, provider, providerId, Role.USER);
+    }
+
+    // Full constructor including role
+    public User(String name, String email, String pictureUrl, String provider, String providerId, Role role) {
         this.name = name;
         this.email = email;
         this.pictureUrl = pictureUrl;
         this.provider = provider;
         this.providerId = providerId;
+        this.role = role;
         this.isActive = true;
     }
 
@@ -86,6 +97,9 @@ public class User {
 
     public String getProviderId() { return providerId; }
     public void setProviderId(String providerId) { this.providerId = providerId; }
+
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
 
     public Boolean getIsActive() { return isActive; }
     public void setIsActive(Boolean isActive) { this.isActive = isActive; }
@@ -116,6 +130,7 @@ public class User {
                 ", name='" + name + '\'' +
                 ", email='" + email + '\'' +
                 ", provider='" + provider + '\'' +
+                ", role=" + role +
                 ", isActive=" + isActive +
                 ", createdAt=" + createdAt +
                 '}';

--- a/src/main/java/mayankSuperApp/auth_service/service/UserService.java
+++ b/src/main/java/mayankSuperApp/auth_service/service/UserService.java
@@ -3,6 +3,7 @@ package mayankSuperApp.auth_service.service;
 
 import mayankSuperApp.auth_service.dto.UserDto;
 import mayankSuperApp.auth_service.entity.User;
+import mayankSuperApp.auth_service.entity.Role;
 import mayankSuperApp.auth_service.exception.ResourceNotFoundException;
 import mayankSuperApp.auth_service.repository.UserRepository;
 import mayankSuperApp.auth_service.security.CustomUserPrincipal;
@@ -69,7 +70,7 @@ public class UserService implements UserDetailsService {
             return user;
         } else {
             // Create new user
-            User newUser = new User(name, email, picture, provider, providerId);
+            User newUser = new User(name, email, picture, provider, providerId, Role.USER);
             User savedUser = userRepository.save(newUser);
 
             logger.info("Created new user: {}", email);


### PR DESCRIPTION
## Summary
- introduce `Role` enum with `USER` and `ADMIN`
- add `role` column to `User` entity and constructors
- include role in service when creating a user

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6856d6b9eeec832a835bed2e2271f912