### PR TITLE
Add role claim to user DTO and JWT generation

### DIFF
--- a/src/main/java/mayankSuperApp/auth_service/dto/UserDto.java
+++ b/src/main/java/mayankSuperApp/auth_service/dto/UserDto.java
@@ -29,19 +29,23 @@ public class UserDto {
     @Schema(description = "OAuth provider", example = "google")
     private String provider;
 
+    @Schema(description = "User role", example = "ROLE_USER")
+    private String role;
+
     @Schema(description = "Account creation timestamp")
     private LocalDateTime createdAt;
 
     // Constructors
     public UserDto() {}
 
-    public UserDto(Long id, String name, String email, String pictureUrl, String provider, LocalDateTime createdAt) {
+    public UserDto(Long id, String name, String email, String pictureUrl, String provider, LocalDateTime createdAt, String role) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.pictureUrl = pictureUrl;
         this.provider = provider;
         this.createdAt = createdAt;
+        this.role = role;
     }
 
     // Getters and Setters
@@ -59,6 +63,9 @@ public class UserDto {
 
     public String getProvider() { return provider; }
     public void setProvider(String provider) { this.provider = provider; }
+
+    public String getRole() { return role; }
+    public void setRole(String role) { this.role = role; }
 
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/mayankSuperApp/auth_service/service/JwtService.java
+++ b/src/main/java/mayankSuperApp/auth_service/service/JwtService.java
@@ -27,10 +27,12 @@ public class JwtService {
      */
     public JwtResponse generateTokenResponse(User user) {
         try {
+            String role = "ROLE_USER";
             String accessToken = jwtUtil.generateToken(
                     user.getEmail(),
                     user.getId(),
-                    user.getName()
+                    user.getName(),
+                    role
             );
             long expiresIn = jwtUtil.getExpirationTime() / 1_000; // seconds
 
@@ -40,7 +42,8 @@ public class JwtService {
                     user.getEmail(),
                     user.getPictureUrl(),
                     user.getProvider(),
-                    user.getCreatedAt()
+                    user.getCreatedAt(),
+                    role
             );
 
             logger.info("Generated JWT token for user: {}", user.getEmail());

--- a/src/main/java/mayankSuperApp/auth_service/service/UserService.java
+++ b/src/main/java/mayankSuperApp/auth_service/service/UserService.java
@@ -131,13 +131,15 @@ public class UserService implements UserDetailsService {
     }
 
     private UserDto convertToDto(User user) {
+        String role = "ROLE_USER";
         return new UserDto(
                 user.getId(),
                 user.getName(),
                 user.getEmail(),
                 user.getPictureUrl(),
                 user.getProvider(),
-                user.getCreatedAt()
+                user.getCreatedAt(),
+                role
         );
     }
 }

--- a/src/main/java/mayankSuperApp/auth_service/util/JwtUtil.java
+++ b/src/main/java/mayankSuperApp/auth_service/util/JwtUtil.java
@@ -31,11 +31,12 @@ public class JwtUtil {
         return Keys.hmacShaKeyFor(secret.getBytes());
     }
 
-    public String generateToken(String email, Long userId, String name) {
+    public String generateToken(String email, Long userId, String name, String role) {
         Map<String, Object> claims = new HashMap<>();
         claims.put("userId", userId);
         claims.put("name", name);
         claims.put("email", email);
+        claims.put("role", role);
         claims.put("type", "access");
 
         return createToken(claims, email, expiration);


### PR DESCRIPTION
## Summary
- add `role` field to `UserDto`
- include user role when generating JWT tokens
- populate `UserDto.role` when converting entities

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6856d6c6a8bc832a9294f8732649ae6a