### PR TITLE
Add issue report API

### DIFF
--- a/src/main/java/mayankSuperApp/auth_service/controller/IssueReportController.java
+++ b/src/main/java/mayankSuperApp/auth_service/controller/IssueReportController.java
@@ -1,0 +1,33 @@
+package mayankSuperApp.auth_service.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import mayankSuperApp.auth_service.dto.IssueReportRequest;
+import mayankSuperApp.auth_service.dto.IssueReportResponse;
+import mayankSuperApp.auth_service.service.IssueReportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/report")
+@Tag(name = "Issue Report", description = "Endpoints to submit road issue reports")
+public class IssueReportController {
+
+    private final IssueReportService service;
+
+    @Autowired
+    public IssueReportController(IssueReportService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Submit a new issue report")
+    @ApiResponse(responseCode = "200", description = "Report created successfully")
+    @PostMapping
+    public ResponseEntity<IssueReportResponse> createReport(@Valid @RequestBody IssueReportRequest request) {
+        IssueReportResponse response = service.createReport(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/mayankSuperApp/auth_service/dto/IssueReportRequest.java
+++ b/src/main/java/mayankSuperApp/auth_service/dto/IssueReportRequest.java
@@ -1,0 +1,80 @@
+package mayankSuperApp.auth_service.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Request payload for reporting a road issue")
+public class IssueReportRequest {
+
+    @NotBlank
+    @Schema(description = "Title of the issue", example = "Pothole on Main Street")
+    private String title;
+
+    @NotBlank
+    @Schema(description = "Detailed description", example = "Large pothole causing traffic disruption near the intersection")
+    private String description;
+
+    @NotBlank
+    @Schema(description = "Road or location", example = "Main Street")
+    private String roads;
+
+    @NotBlank
+    @Schema(description = "Priority level", example = "High Priority")
+    private String low;
+
+    @NotBlank
+    @Schema(description = "Responsible MP", example = "John Smith")
+    private String mp;
+
+    @NotBlank
+    @Schema(description = "Base64 encoded image string")
+    private String image;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getRoads() {
+        return roads;
+    }
+
+    public void setRoads(String roads) {
+        this.roads = roads;
+    }
+
+    public String getLow() {
+        return low;
+    }
+
+    public void setLow(String low) {
+        this.low = low;
+    }
+
+    public String getMp() {
+        return mp;
+    }
+
+    public void setMp(String mp) {
+        this.mp = mp;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+}

--- a/src/main/java/mayankSuperApp/auth_service/dto/IssueReportResponse.java
+++ b/src/main/java/mayankSuperApp/auth_service/dto/IssueReportResponse.java
@@ -1,0 +1,37 @@
+package mayankSuperApp.auth_service.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Response after creating an issue report")
+public class IssueReportResponse {
+
+    @Schema(description = "Generated report id")
+    private Long id;
+
+    @Schema(description = "Response message")
+    private String message;
+
+    public IssueReportResponse() {
+    }
+
+    public IssueReportResponse(Long id, String message) {
+        this.id = id;
+        this.message = message;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/mayankSuperApp/auth_service/entity/IssueReport.java
+++ b/src/main/java/mayankSuperApp/auth_service/entity/IssueReport.java
@@ -1,0 +1,108 @@
+package mayankSuperApp.auth_service.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "issue_reports")
+public class IssueReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String description;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String roads;
+
+    @NotBlank
+    @Column(name = "priority", nullable = false)
+    private String low;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String mp;
+
+    @Lob
+    @Column(nullable = false)
+    private String image;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getRoads() {
+        return roads;
+    }
+
+    public void setRoads(String roads) {
+        this.roads = roads;
+    }
+
+    public String getLow() {
+        return low;
+    }
+
+    public void setLow(String low) {
+        this.low = low;
+    }
+
+    public String getMp() {
+        return mp;
+    }
+
+    public void setMp(String mp) {
+        this.mp = mp;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/mayankSuperApp/auth_service/repository/IssueReportRepository.java
+++ b/src/main/java/mayankSuperApp/auth_service/repository/IssueReportRepository.java
@@ -1,0 +1,9 @@
+package mayankSuperApp.auth_service.repository;
+
+import mayankSuperApp.auth_service.entity.IssueReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IssueReportRepository extends JpaRepository<IssueReport, Long> {
+}

--- a/src/main/java/mayankSuperApp/auth_service/service/IssueReportService.java
+++ b/src/main/java/mayankSuperApp/auth_service/service/IssueReportService.java
@@ -1,0 +1,34 @@
+package mayankSuperApp.auth_service.service;
+
+import mayankSuperApp.auth_service.dto.IssueReportRequest;
+import mayankSuperApp.auth_service.dto.IssueReportResponse;
+import mayankSuperApp.auth_service.entity.IssueReport;
+import mayankSuperApp.auth_service.repository.IssueReportRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class IssueReportService {
+
+    private final IssueReportRepository repository;
+
+    @Autowired
+    public IssueReportService(IssueReportRepository repository) {
+        this.repository = repository;
+    }
+
+    public IssueReportResponse createReport(IssueReportRequest request) {
+        IssueReport report = new IssueReport();
+        report.setTitle(request.getTitle());
+        report.setDescription(request.getDescription());
+        report.setRoads(request.getRoads());
+        report.setLow(request.getLow());
+        report.setMp(request.getMp());
+        report.setImage(request.getImage());
+
+        IssueReport saved = repository.save(report);
+        return new IssueReportResponse(saved.getId(), "Report submitted successfully");
+    }
+}


### PR DESCRIPTION
## Summary
- create `IssueReport` entity for road issue reports
- add DTOs for submitting and returning an issue report
- implement repository, service and controller for `/report`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687128a5b250832ab8088ab722e969b0